### PR TITLE
Update MPModManager.lua to prevent mod disable

### DIFF
--- a/lua/ge/extensions/MPModManager.lua
+++ b/lua/ge/extensions/MPModManager.lua
@@ -100,7 +100,7 @@ local function checkMod(mod) --TODO: might have a flaw with repo mods as their n
 
 	if not modAllowed and mod.active then
 		log('W', 'checkMod', "This mod should not be running: "..modname)
-		core_modmanager.deactivateMod(modname)
+	-- Deleted Line to prevent disabling of mods -- Would prefer a switch to turn on and off -- Ausdboss
 		if mod.dirname == '/mods/multiplayer/' then
 			core_modmanager.deleteMod(modname)
 		end


### PR DESCRIPTION
I deleted line 103. It prevents mods being disabled when launching BeamNG through the BeamMP launcher and joining a server. Many people have asked on Reddit for the past couple years asking if there was a way to stop disabling of mods so they don't have to enable UI mods again, or so friends can play in Vanilla servers with all the mods they use and it syncs perfectly, as well as adding mods to servers that don't have all the mods you want. In my case it's also to save space so you don't have to re-download mods you already have for a server and so I don't have to enable a script in the editor and then re activate my 82 mods with my friend every single time we play, takes like 20 mins, and prevented us from actually playing the game. Now we have been playing non stop and love it! I want to share the love with others! I think this would work best as an on and off switch so you can keep the current functionality or use this new method of mods not disabling. Has been a GAME CHANGER for me and have had no issues! Hope you guys enjoy!